### PR TITLE
chore: move jsonwebtoken typings to dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "type": "git",
     "url": "git+https://github.com/stefan-prokop-cz/verify-apple-id-token.git"
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "keywords": [
     "verify",
     "apple",

--- a/package.json
+++ b/package.json
@@ -15,9 +15,7 @@
     "type": "git",
     "url": "git+https://github.com/stefan-prokop-cz/verify-apple-id-token.git"
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "keywords": [
     "verify",
     "apple",
@@ -36,12 +34,12 @@
     "url": "https://github.com/stefan-prokop-cz/verify-apple-id-token/issues"
   },
   "dependencies": {
-    "@types/jsonwebtoken": "^9.0.5",
     "jsonwebtoken": "^9.0.2",
     "jwks-rsa": "^3.1.0"
   },
   "devDependencies": {
     "@types/jest": "29.5.11",
+    "@types/jsonwebtoken": "^9.0.5",
     "@typescript-eslint/eslint-plugin": "^6.16.0",
     "@typescript-eslint/parser": "^6.16.0",
     "eslint": "^8.56.0",


### PR DESCRIPTION
Hi! thanks for this nice package.

Following https://github.com/stefanprokopdev/verify-apple-id-token/commit/391099c09c58ab2ff663b9b28e00a6a66df47bab#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R39, one of the typings moved to non-dev deps.

This PR is just moving it back, as it should not be needed on prod, wdyt?

Have a great day 👋 

edit: looks like I cannot set you as a reviewer for some reason 👀 